### PR TITLE
Fix for issue #12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.6)
 project("Tablet-Visualizer" LANGUAGES CXX)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.27)
+cmake_minimum_required(VERSION 3.5)
 project("Tablet-Visualizer" LANGUAGES CXX)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)

--- a/Visualizer.hpp
+++ b/Visualizer.hpp
@@ -74,6 +74,10 @@ private:
 #endif
 #if WindowsOS == 1
     sf::Vector2i _GetDesktopDimensions();
+    // Fix for console showing up in windows 11 even when disabled by ShowWindow(GetConsoleWindow(), SW_HIDE)
+    // Takes two handles of console one when on windows 10 and second when on 11
+    void         _HideConsole(HWND& W10ConsoleHandle, HWND& W11ConsoleHandle);
+    void         _ShowConsole(HWND& W10ConsoleHandle, HWND& W11ConsoleHandle);
 #endif
 
 private:

--- a/src/Visualizer.cpp
+++ b/src/Visualizer.cpp
@@ -1,5 +1,4 @@
 #include "../Visualizer.hpp"
-#include "Visualizer.hpp"
 
 
 TVis::Visualizer::Visualizer() :

--- a/src/Visualizer.cpp
+++ b/src/Visualizer.cpp
@@ -1,4 +1,5 @@
 #include "../Visualizer.hpp"
+#include "Visualizer.hpp"
 
 
 TVis::Visualizer::Visualizer() :
@@ -10,14 +11,21 @@ TVis::Visualizer::Visualizer() :
 void TVis::Visualizer::Init()
 {
 #if WindowsOS == 1
+    HWND consoleWindowW10 = GetConsoleWindow();
+    Sleep(2); // There needs to be delay because console widnow might not initialize in time and console will still appear in windows 11
+    HWND consoleWindowW11 = GetWindow(consoleWindowW10, GW_OWNER);
 
     if (_LoadSettingsFile())
-        ShowWindow(GetConsoleWindow(), SW_HIDE);
+    {
+        _HideConsole(consoleWindowW10, consoleWindowW11);
+    }
     else
         ShowWindow(GetConsoleWindow(), SW_SHOW);
 
     if (_EnableErrors == false) // Manually disable errors console in Settings.json
-        ShowWindow(GetConsoleWindow(), SW_HIDE);
+    {
+        _HideConsole(consoleWindowW10, consoleWindowW11);
+    }
 
     _DesktopDimensions = _GetDesktopDimensions();
 
@@ -294,5 +302,21 @@ sf::Vector2i TVis::Visualizer::_GetDesktopDimensions()
 	GetWindowRect(hDesktop, &desktop);
 
     return sf::Vector2i(desktop.right, desktop.bottom);
+}
+
+void TVis::Visualizer::_HideConsole(HWND& W10ConsoleHandle, HWND& W11ConsoleHandle)
+{
+    if (W11ConsoleHandle == NULL)
+        ShowWindow(GetConsoleWindow(), SW_HIDE);
+    else
+        ShowWindow(W11ConsoleHandle, SW_HIDE);
+}
+
+void TVis::Visualizer::_ShowConsole(HWND &W10ConsoleHandle, HWND &W11ConsoleHandle)
+{
+    if (W11ConsoleHandle == NULL)
+        ShowWindow(GetConsoleWindow(), SW_SHOW);
+    else
+        ShowWindow(W11ConsoleHandle, SW_SHOW);
 }
 #endif


### PR DESCRIPTION
- https://github.com/xO-3670/Tablet-Visualizer/issues/12#issue-2966052894
- On windows 11 console would still appear even when disabled by normal ShowWindow function. This fixes the issue, it adds two new functions for showing and hiding console window which check if window handle is windows 10 or 11
